### PR TITLE
Решать, что уходит наружу, до того как ревьюеры что-то прочитают

### DIFF
--- a/scripts/review-codex.sh
+++ b/scripts/review-codex.sh
@@ -46,7 +46,7 @@ case "$DIFF" in -*) echo "--diff must be a revision, not an option: $DIFF" >&2; 
 # --- what to look at -----------------------------------------------------
 if [ -n "$DIFF" ]; then
   case "$DIFF" in
-    uncommitted) HOW="Find it with: git status --porcelain --untracked-files=all, git diff, git diff --cached. Untracked files count as changes." ;;
+    uncommitted) HOW="Find it with: git diff and git diff --cached. Do NOT list the working tree yourself: untracked files reach you only through the paths restriction below, which was decided before this prompt was built." ;;
     *)           HOW="Find it with: git diff ${DIFF} (or git show ${DIFF} if that is a single commit)." ;;
   esac
   TARGET_LINE="Review this change: ${TARGET}. ${HOW}"

--- a/scripts/review-opencode.sh
+++ b/scripts/review-opencode.sh
@@ -41,7 +41,7 @@ PS=""
 
 if [ -n "$DIFF" ]; then
   case "$DIFF" in
-    uncommitted) HOW="Run this to see it: git status --porcelain --untracked-files=all${PS} && git diff${PS} && git diff --cached${PS}" ;;
+    uncommitted) HOW="Run this to see it: git diff${PS} && git diff --cached${PS}   (do NOT list the working tree yourself — untracked files reach you only through the paths restriction below)" ;;
     *)           HOW="Run this to see it: git diff ${DIFF}${PS}   (if that is a single commit, use git show ${DIFF}${PS} instead)" ;;
   esac
   TARGET_LINE="Review this change: ${TARGET}

--- a/scripts/safe-paths.sh
+++ b/scripts/safe-paths.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Decide WHICH paths the external reviewers are allowed to see — by name only,
+# before anybody reads a single byte of content.
+#
+#   safe-paths.sh --diff uncommitted
+#   safe-paths.sh --diff "main...HEAD"
+#   safe-paths.sh --paths "src/auth.py src/session.py"
+#   safe-paths.sh --self-test
+#
+# Why this exists, and why it runs FIRST:
+#
+#   The reviewers are told to find the change themselves — and the honest way
+#   to describe an uncommitted change includes untracked files, because a
+#   brand-new file is the change. But "untracked" is also where a working tree
+#   keeps the things that were never meant to leave the machine: .env.local, a
+#   deploy key somebody dropped in the repo root, a service-account JSON, this
+#   plugin's own providers.env. Handing an external model the instruction
+#   "list the working tree and read what you find" hands it those too, and by
+#   the time any filter could look at the content, the content is already in
+#   somebody else's prompt.
+#
+#   So the order is inverted: names first, content never here. This script
+#   looks at path names, drops the ones that match a deny rule, and prints an
+#   explicit allow-list. The reviewers then get that list through --paths and
+#   are told not to widen it. Nothing is filtered after the fact, because after
+#   the fact is too late.
+#
+# It is deliberately path-only. It does not open files, does not grep for
+# high-entropy strings, and does not try to be a secret scanner: a scanner that
+# reads content to decide whether content may be read has already lost.
+#
+# Output (stdout), machine-readable, one item per line:
+#
+#   allow: <path>
+#   withheld: <path> <rule>
+#   summary: <n> allowed, <m> withheld
+#
+# Exit codes: 0 = decided; 2 = usage error or scope could not be resolved.
+# Fail-closed: if the scope cannot be resolved, nothing is allowed. An empty
+# allow-list is a valid answer and means "do not send anything", never
+# "send everything".
+set -uo pipefail
+
+DIFF=""; PATHS=""; SELFTEST=0
+need() { [ "$1" -ge 2 ] || { echo "missing value for $2" >&2; exit 2; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --diff) need $# "$1"; DIFF="$2"; shift 2 ;;
+    --paths) need $# "$1"; PATHS="$2"; shift 2 ;;
+    --self-test) SELFTEST=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Same guard as the other scripts: a revision starting with "-" is an option to
+# git, not a revision.
+case "$DIFF" in -*) echo "--diff must be a revision, not an option: $DIFF" >&2; exit 2 ;; esac
+
+# --- the deny rules ------------------------------------------------------
+#
+# Matched with `case` against the full path and against the basename, so a
+# rule catches both `.env.local` and `config/.env.local`. Kept as literal
+# globs rather than one regex on purpose: this list is meant to be read and
+# extended by whoever is looking at their own repo, not decoded.
+#
+# The allow-listed exceptions come first — .env.example is the file whose
+# entire job is to be committed and shared, and withholding it would hide a
+# real part of the change for no gain.
+deny_rule() { # deny_rule <path> -> prints the rule that killed it, or nothing
+  local p="$1" b
+  b="${p##*/}"
+
+  case "$b" in
+    .env.example|.env.sample|.env.template|.env.dist|env.example) return 0 ;;
+  esac
+
+  case "$b" in
+    .env|.env.*|*.env)                 echo "env-file";     return 0 ;;
+    .netrc|.pgpass|.htpasswd|.npmrc)   echo "credentials";  return 0 ;;
+    id_rsa*|id_dsa*|id_ecdsa*|id_ed25519*) echo "ssh-key";  return 0 ;;
+    *_rsa|*_dsa|*_ecdsa|*_ed25519)     echo "ssh-key";      return 0 ;;
+    *.pem|*.key|*.p8|*.p12|*.pfx|*.jks|*.keystore) echo "key-material"; return 0 ;;
+    *secret*|*Secret*|*SECRET*)        echo "secret-name";  return 0 ;;
+    *credential*|*Credential*)         echo "credentials";  return 0 ;;
+    *service-account*|*serviceaccount*) echo "service-account"; return 0 ;;
+    *.sqlite|*.sqlite3|*.db|*.dump)    echo "local-data";    return 0 ;;
+  esac
+
+  case "$p" in
+    .ssh/*|*/.ssh/*)         echo "ssh-dir";     return 0 ;;
+    .aws/*|*/.aws/*)         echo "cloud-creds"; return 0 ;;
+    .gnupg/*|*/.gnupg/*)     echo "gpg-dir";     return 0 ;;
+    .docker/config.json|*/.docker/config.json) echo "registry-auth"; return 0 ;;
+    .claude/multi/*|*/.claude/multi/*) echo "plugin-keys";  return 0 ;;
+  esac
+
+  return 0
+}
+
+# --- collecting the scope ------------------------------------------------
+# Names only. `git diff --name-only` and `git ls-files` never open a file.
+collect() {
+  local files=""
+  if [ -n "$DIFF" ]; then
+    case "$DIFF" in
+      uncommitted)
+        files="$( { git diff --name-only;
+                    git diff --cached --name-only;
+                    git ls-files --others --exclude-standard; } 2>/dev/null | sort -u )"
+        ;;
+      *)
+        files="$(git diff --name-only "$DIFF" -- 2>/dev/null)" \
+          || files="$(git show --name-only --format="" "$DIFF" -- 2>/dev/null)" \
+          || return 1
+        ;;
+    esac
+  fi
+
+  if [ -n "$PATHS" ]; then
+    local arr=() narrowed="" f p
+    read -r -a arr <<<"$PATHS"
+    if [ -n "$files" ]; then
+      while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        for p in "${arr[@]}"; do
+          case "$f" in "$p"|"$p"/*) narrowed="$narrowed$f"$'\n'; break ;; esac
+        done
+      done <<<"$files"
+      files="$(printf '%s' "$narrowed")"
+    else
+      files="$( { git ls-files -- "${arr[@]}" 2>/dev/null; printf '%s\n' "${arr[@]}"; } | sort -u )"
+    fi
+  fi
+
+  printf '%s' "$files"
+}
+
+decide() {
+  local files allowed=0 withheld=0 f rule
+  files="$(collect)" || {
+    # Unresolvable scope. Say so and allow nothing — an unreadable range must
+    # not degrade into "review the whole working tree".
+    echo "summary: 0 allowed, 0 withheld (scope unresolved: ${DIFF:-$PATHS})"
+    return 2
+  }
+
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    rule="$(deny_rule "$f")"
+    if [ -n "$rule" ]; then
+      echo "withheld: $f $rule"
+      withheld=$(( withheld + 1 ))
+    else
+      echo "allow: $f"
+      allowed=$(( allowed + 1 ))
+    fi
+  done <<<"$files"
+
+  echo "summary: $allowed allowed, $withheld withheld"
+  return 0
+}
+
+# --- self-test -----------------------------------------------------------
+#
+# Two assertions, and the negative one alone would not be enough: a script
+# that withholds EVERYTHING also passes "the .env was withheld". So the test
+# checks both directions — the secret is gone AND the ordinary source file is
+# still there. Break the deny list and the first fails; break collection and
+# the second fails.
+self_test() {
+  local tmp rc=0 out
+  tmp="$(mktemp -d)" || { echo "self-test: cannot create tmpdir" >&2; return 1; }
+  (
+    cd "$tmp" || exit 1
+    git init -q .
+    mkdir -p src
+    printf 'print("hi")\n' > src/app.py
+    printf 'TOKEN=live-value\n' > .env.local
+    printf 'x\n' > deploy_rsa
+    git add -A >/dev/null 2>&1
+  ) || { rm -rf "$tmp"; echo "self-test: fixture failed" >&2; return 1; }
+
+  out="$(cd "$tmp" && DIFF=uncommitted PATHS="" "$SELF" --diff uncommitted)"
+
+  printf '%s\n' "$out" | grep -q '^allow: src/app\.py$' || {
+    echo "self-test FAIL: ordinary source file was not allowed through"; rc=1; }
+  printf '%s\n' "$out" | grep -q '^withheld: \.env\.local env-file$' || {
+    echo "self-test FAIL: .env.local reached the allow list"; rc=1; }
+  printf '%s\n' "$out" | grep -q '^withheld: deploy_rsa ssh-key$' || {
+    echo "self-test FAIL: private key reached the allow list"; rc=1; }
+  printf '%s\n' "$out" | grep -q '^allow: \.env\.local$' && {
+    echo "self-test FAIL: .env.local appears in allow"; rc=1; }
+
+  rm -rf "$tmp"
+  [ "$rc" = 0 ] && echo "self-test OK — 3 checks (1 positive control, 2 negative)"
+  return "$rc"
+}
+
+SELF="$(cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")"
+
+if [ "$SELFTEST" = "1" ]; then
+  self_test
+  exit $?
+fi
+
+[ -n "$DIFF" ] || [ -n "$PATHS" ] || { echo "usage: safe-paths.sh --diff <spec> | --paths \"<paths>\" | --self-test" >&2; exit 2; }
+git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "not a git repo" >&2; exit 2; }
+
+decide
+exit $?

--- a/skills/check-if-done/SKILL.md
+++ b/skills/check-if-done/SKILL.md
@@ -56,6 +56,18 @@ Changed:  <concrete paths or range>
 They are free and slow to start, so they go first and run in the background
 while you do the real work below.
 
+Settle the allow-list first — this skill hands the outside reviewers a target
+just like the review skill does, and an unfinished task lives in an untracked
+working tree more often than not:
+
+```bash
+$SCRIPTS/safe-paths.sh [--diff <spec>] [--paths "<paths>"]
+```
+
+Describe only the allowed paths in the prompt below, and say in the report if
+anything was withheld — a completion check that silently skipped part of the
+change is the one failure this skill cannot afford.
+
 ```bash
 cat > /tmp/multi-done-prompt.md <<'EOF'
 <the promise, as a concrete list of what was supposed to end up working>

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -95,6 +95,26 @@ conditional on a mode. Start the two external ones **in the background, both at
 once** — OpenCode spends about a minute just warming up — and do everything
 else while they run.
 
+**Decide what may leave the machine, before anything is read.** The external
+reviewers run somewhere else, and an uncommitted target is exactly where a
+working tree keeps what was never meant to travel — `.env.local`, a stray
+deploy key, a service-account JSON, this plugin's own `providers.env`. So the
+allow-list is settled first, by path name only:
+
+```bash
+$SCRIPTS/safe-paths.sh [--diff <spec>] [--paths "<paths>"]
+```
+
+It prints `allow:` lines, `withheld:` lines with the rule that caught them, and
+a one-line summary. Pass the allowed paths on as `--paths` to both external
+reviewers below — that is what keeps them from widening the scope themselves —
+and repeat the withheld count in the report, so a reviewer that saw less than
+the whole change says so out loud. An empty allow-list means send nothing, not
+send everything.
+
+Ordinary repositories withhold nothing and the line is free. Skip the step only
+when the target is a committed range you already know is clean.
+
 ```bash
 $SCRIPTS/collect-context.sh [--diff <spec>] [--paths "<paths>"] > /tmp/multi-ctx.md
 


### PR DESCRIPTION
Привет! Разбирал плагин, чтобы понять, ставить ли его глобально — и наткнулся на одну вещь, которую починил сразу, вместо того чтобы просто завести issue. Пишу по-русски, раз мы оба, коммит оставил на английском, как и всё в репо.

## Проблема

Ревьюерам сейчас передаётся инструкция найти изменения самим, включая untracked:

```
scripts/review-codex.sh:49     git status --porcelain --untracked-files=all ... Untracked files count as changes.
scripts/review-opencode.sh:44  git status --porcelain --untracked-files=all${PS} && ...
```

Для описания незакоммиченной правки это честно: свежесозданный файл и есть изменение, без него ревью неполное. Но untracked — ещё и то место, где рабочее дерево держит вещи, которые уезжать не должны: `.env.local`, забытый в корне deploy-ключ, service-account JSON, и — отдельная ирония — `providers.env` самого плагина. На публичной песочнице это ничего не стоит, на приватном репозитории это отправка секретов наружу, причём **фильтр после сбора уже не помогает**: чтобы решить, можно ли показывать содержимое, его придётся прочитать, а прочитанное уже в чужом промпте.

Отказ тихий вдвойне. В отчёте ничего не появляется, скоуп при этом самый естественный — «мои текущие изменения», то есть ровно то, что человек выберет по умолчанию.

## Что предлагаю

Развернуть порядок: **сначала имена, содержимое здесь не читается никогда.**

Новый `scripts/safe-paths.sh` собирает пути в скоупе (`git diff --name-only`, `git ls-files` — ни одного открытия файла), прогоняет их через список deny-правил по имени и печатает машиночитаемо:

```
allow: src/app.py
withheld: .env.local env-file
withheld: deploy_rsa ssh-key
summary: 1 allowed, 2 withheld
```

Дальше разрешённые пути уходят обоим внешним ревьюерам через `--paths`, а в их промптах теперь прямо сказано не расширять скоуп самостоятельно. Число withheld просится в отчёт — ревьюер, видевший не всю правку, должен сказать это вслух, иначе «чисто» означает не то, что кажется.

Три свойства, на которых всё держится:

- **Fail-closed.** Не разрешился скоуп (опечатка в ref, не тот репозиторий) — `rc=2` и пустой allow-list. Пустой список значит «не отправлять ничего», никогда «отправить всё».
- **Path-only по построению.** Скрипт не открывает файлы, не ищет высокоэнтропийные строки и не пытается быть сканером секретов: сканер, читающий содержимое ради решения, можно ли читать содержимое, уже проиграл.
- **Обычный репозиторий ничего не теряет.** Прогон на этом же репо: `5 allowed, 0 withheld`. `.env.example` и родня — в белом списке, их работа как раз в том, чтобы лежать в репозитории.

## Дифф

| Файл | Что |
|---|---|
| `scripts/safe-paths.sh` | новый — решение о скоупе + `--self-test` |
| `scripts/review-codex.sh` | 1 строка: не перечислять рабочее дерево самому |
| `scripts/review-opencode.sh` | 1 строка: то же |
| `skills/code-review/SKILL.md` | шаг перед запуском ревьюеров |
| `skills/check-if-done/SKILL.md` | тот же шаг — он отправляет наружу так же |

34 добавленные строки в существующих файлах, остальное — новый скрипт. Логику ревью не трогал.

## Как проверено

`--self-test` поднимает временный репозиторий с `src/app.py`, `.env.local` и `deploy_rsa` и делает **три** проверки, из них одна позитивная. Позитивная тут не для красоты: скрипт, который прячет вообще всё, проходит обе негативные проверки, и без «обычный файл обязан пройти» тест был бы зелёным на сломанном коде.

Проверил мутациями, что тест действительно ловит:

| Мутант | Результат |
|---|---|
| снять deny-правило `env-file` | падают обе негативные проверки |
| заставить сбор путей возвращать пусто | падает позитивная проверка |
| — (чистый код) | `self-test OK — 3 checks` |

Плюс живой прогон на этом репозитории (5 разрешено, 0 исключено) и на несуществующем ref (`rc=2`, пустой allow-list).

## Чего намеренно не делал

- **README не трогал** — ты его правишь чаще всего, конфликт был бы гарантирован. Скажи, если нужна строчка, добавлю в том же PR.
- **Драйвер Codex не трогал.** Сперва думал, что переход с плагин-рантайма на `codex exec` потерял накопленные обходы, полез проверять — и нет: в коммите v2 у тебя прямо написано, почему плагинные команды не оркестрируются, а обе гочи самого CLI (кастомный промпт несовместим с флагами скоупа; `effort` по умолчанию `none`) уже учтены в комментариях `review-codex.sh`. Претензия снята, решение обоснованное.
- **Deny-список намеренно короткий и читаемый** — литеральные globs, а не один регексп: он рассчитан на то, что человек допишет своё под свой репозиторий, а не будет расшифровывать.

## Отдельно, follow-up (в этот PR не тащу)

`gh pr view` не встречается в плагине ни разу, то есть «отревьюй PR 42» сейчас никак не превращается в скоуп. Наивная версия (`main...HEAD`) тихо ревьюит не тот дифф в двух случаях: PR открыт против нерелизного base (стек веток, релизные линии) и когда локальный `main` отстал. Резолв — `gh pr view N --json baseRefName,headRefName,headRefOid`. Скажи, нужно ли — сделаю вторым PR, мешать с безопасностью не хочу.

Спасибо за плагин, `check-if-done` — лучшая часть, «модель, только что написавшая код, — худший судья того, работает ли он» стоит того, чтобы быть отдельной командой.
