### PR TITLE
На macOS плагин не запускается: нет timeout, и Codex читается как «не залогинен»

### DIFF
--- a/scripts/probe.sh
+++ b/scripts/probe.sh
@@ -22,7 +22,7 @@ SELF_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
 # --- Codex (required) ---------------------------------------------------
 if command -v codex >/dev/null 2>&1; then
   ver="$(codex --version 2>/dev/null | head -1)"
-  if timeout 10 codex login status 2>&1 | grep -qi 'logged in'; then
+  if multi_timeout 10 codex login status 2>&1 | grep -qi 'logged in'; then
     say "codex: OK — ${ver}"
   else
     say "codex: NOT LOGGED IN — ${ver} (run: codex login)"
@@ -45,7 +45,7 @@ if command -v opencode >/dev/null 2>&1; then
   if [ -n "${MULTI_OPENCODE_MODEL:-}" ]; then
     say "opencode: OK — ${MULTI_OPENCODE_MODEL} (pinned by MULTI_OPENCODE_MODEL)"
   else
-    available="$(timeout 20 opencode models 2>/dev/null)"
+    available="$(multi_timeout 20 opencode models 2>/dev/null)"
     picked=""
     for m in $CANDIDATES; do
       printf '%s\n' "$available" | grep -qxF "$m" && { picked="$m"; break; }

--- a/scripts/providers.sh
+++ b/scripts/providers.sh
@@ -16,6 +16,39 @@
 #      validated with curl (instant, unambiguous), never by launching the
 #      agent, and every child process gets a hard timeout.
 
+# --- timeout, portably --------------------------------------------------
+# `timeout` is GNU coreutils and is NOT on a stock macOS — Homebrew's coreutils
+# installs it as `gtimeout`, and plenty of machines have neither. That matters
+# more than it looks: `timeout 10 codex login status | grep -qi 'logged in'`
+# does not fail loudly when the binary is missing. The shell writes
+# "command not found" to stderr, grep reads an empty stdin, and the probe
+# concludes the user is NOT LOGGED IN — on a machine where Codex is perfectly
+# logged in. The review skill then hits its own gate ("no Codex → stop") and
+# the whole plugin refuses to run.
+#
+# So: real timeout if there is one, otherwise run it ourselves. The fallback
+# is not "skip the timeout" — providers below rely on it, and the note under
+# multi_run_openrouter is exactly why: Claude Code does not fail fast on a bad
+# key, it retries silently, and without a hard limit that call never returns.
+if command -v timeout >/dev/null 2>&1; then
+  multi_timeout() { command timeout "$@"; }
+elif command -v gtimeout >/dev/null 2>&1; then
+  multi_timeout() { command gtimeout "$@"; }
+else
+  multi_timeout() {
+    local secs="$1"; shift
+    "$@" &
+    local pid=$!
+    ( sleep "$secs"; kill -TERM "$pid" 2>/dev/null ) >/dev/null 2>&1 &
+    local watcher=$!
+    wait "$pid" 2>/dev/null
+    local rc=$?
+    kill -TERM "$watcher" >/dev/null 2>&1
+    wait "$watcher" 2>/dev/null
+    return "$rc"
+  }
+fi
+
 MULTI_HOME="${MULTI_HOME:-$HOME/.claude/multi}"
 MULTI_PROVIDERS_ENV="${MULTI_PROVIDERS_ENV:-$MULTI_HOME/providers.env}"
 
@@ -131,7 +164,7 @@ multi_run_openrouter() {
   ANTHROPIC_MODEL="$model" \
   ANTHROPIC_SMALL_FAST_MODEL="$model" \
   ANTHROPIC_DEFAULT_HAIKU_MODEL="$model" \
-    timeout "$MULTI_BACKEND_TIMEOUT" claude -p "$prompt" \
+    multi_timeout "$MULTI_BACKEND_TIMEOUT" claude -p "$prompt" \
       --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
       > "$out" 2> "$log"
   rc=$?
@@ -161,7 +194,7 @@ multi_run_gemini() {
   fi
   command -v gemini >/dev/null 2>&1 || { echo "gemini: MISSING (npm i -g @google/gemini-cli)" > "$out"; return 0; }
   GEMINI_API_KEY="$GEMINI_API_KEY" \
-    timeout "$MULTI_BACKEND_TIMEOUT" gemini -p "$prompt" \
+    multi_timeout "$MULTI_BACKEND_TIMEOUT" gemini -p "$prompt" \
       ${model:+-m "$model"} --approval-mode plan \
       > "$out" 2>&1
   rc=$?


### PR DESCRIPTION
Поставил плагин себе, запустил — и он отказался работать. Оказалось, на macOS он не работает вообще. Пишу по-русски, коммит на английском, как и весь репо.

## Что происходит

`timeout` — это GNU coreutils. На чистом macOS её нет; Homebrew ставит её как `gtimeout`, а на многих машинах нет ни того, ни другого. Отказ при этом **тихий и полный**:

```bash
timeout 10 codex login status 2>&1 | grep -qi 'logged in'
```

Шелл пишет `command not found`, `grep` читает пустой stdin, `probe.sh` печатает `codex: NOT LOGGED IN`. Дальше срабатывает гейт самого скилла — «No Codex, or not logged in → **stop**» — и плагин целиком отказывается запускаться.

Замер на моей машине (macOS, `codex-cli 0.144.6`, залогинен):

```
1. как есть (probe.sh:25)  → codex NOT LOGGED IN
2. что отвечает codex      → Logged in using ChatGPT
3. с shim-функцией         → codex OK
```

То есть Codex подключён, а плагин его не видит и стопорится.

## Почему нельзя просто убрать timeout

Он используется в четырёх местах, и в двух из них он не косметика — это написано в комментарии над `multi_run_openrouter` твоей же рукой: Claude Code **не** падает быстро на плохом ключе, он молча ретраит и не возвращается. Без жёсткого лимита этот вызов висит вечно.

Поэтому фолбэк не «пропустить таймаут», а «сделать его самим».

## Что в патче

`multi_timeout` в `providers.sh` (он и так подключается из `probe.sh`, `ask.sh`, `setup.sh`): берёт `timeout`, если он есть, иначе `gtimeout`, иначе своя реализация через фоновый запуск и сторожа. Все четыре вызова переведены на неё — `probe.sh` ×2 (codex, opencode), `providers.sh` ×2 (openrouter, gemini).

Дифф: **+37 / −4**, два файла, ни одного нового.

## Проверено на машине, где нет ни `timeout`, ни `gtimeout`

| Проверка | Результат |
|---|---|
| быстрая команда отдаёт вывод | `echo hello` → `hello` |
| код возврата успешной команды | `true` → rc=0 |
| код возврата упавшей | `false` → rc=1 |
| **зависшая реально убивается** | `sleep 30` с лимитом 2с → убито за 2с, rc=143 |
| работает в конвейере | тот самый вызов из `probe.sh` → codex распознан |

Последняя строка важнее прочих: shim, который «не падает», но и не убивает зависший процесс, был бы хуже исходного бага — он бы молча вернул openrouter к бесконечному ретраю.

Воспроизвести можно так (на маке без coreutils):

```bash
command -v timeout gtimeout || echo "нет ни того, ни другого"
timeout 10 codex login status 2>&1 | grep -qi 'logged in' && echo OK || echo "NOT LOGGED IN"
codex login status
```

## Отношение к PR #2

Ветка отведена от `main`, а не от `feat/safe-paths-preflight` — они независимы, порядок влития любой, стека не будет. Этот PR я бы взял вперёд того: там гипотетический риск, здесь продукт не стартует на целой платформе.
