### PR TITLE
collect-context: резать по границе символа, а не байта (закрывает #6)

### DIFF
--- a/scripts/collect-context.sh
+++ b/scripts/collect-context.sh
@@ -100,6 +100,30 @@ fi
 # the rule that actually applies gets a chance.
 SHALLOW="$(printf '%s\n' "$DIRS" | awk -F/ 'NF<=3')"
 
+# `head -c` cuts on a BYTE boundary. In a non-ASCII canon — Cyrillic, Thai, CJK, or just an
+# emoji — the cut lands mid-codepoint and ctx.md ends with a partial UTF-8 sequence. That is
+# not cosmetic: `codex exec review` refuses the whole prompt with
+#   error: invalid UTF-8 was detected in one or more arguments
+# which reads as a bug in the prompt and sends you looking in the wrong place, while whatever
+# the reviewer would have said is simply lost. OpenCode swallows the bad byte instead, so the
+# corrupted canon reaches that reviewer silently.
+#
+# Measured on a Russian CLAUDE.md (two independent sessions, byte-identical result):
+#   head -c 8000            → 8000 bytes, invalid continuation byte at offset 7999
+#   head -c 8000 | iconv -c → 7999 bytes, valid  (one byte lost)
+#   head -c 8000 | sed '$d' → 6980 bytes, valid  (the whole trailing line lost)
+#
+# iconv is preferred because it keeps everything but the partial character; dropping the last
+# line is the fallback for systems without iconv, and it is safe for the same reason — a line
+# break is always a character boundary.
+truncate_utf8() { # truncate_utf8 <path> <bytes>
+  if command -v iconv >/dev/null 2>&1; then
+    head -c "$2" "$1" | iconv -f utf-8 -t utf-8 -c 2>/dev/null
+  else
+    head -c "$2" "$1" | sed '$d'
+  fi
+}
+
 total=0
 emit() { # emit <label> <path>
   label="$1"; path="$2"
@@ -108,7 +132,7 @@ emit() { # emit <label> <path>
   [ "$total" -lt "$MAX_TOTAL_BYTES" ] || return 0
   printf '\n### %s\n\n' "$label"
   if [ "$size" -gt "$MAX_FILE_BYTES" ]; then
-    head -c "$MAX_FILE_BYTES" "$path"
+    truncate_utf8 "$path" "$MAX_FILE_BYTES"
     printf '\n[...truncated, %s bytes total...]\n' "$size"
     total=$(( total + MAX_FILE_BYTES ))
   else


### PR DESCRIPTION
Закрывает #6 — «Кириллица UTF-8». Это не косметика: из-за неё Codex молча выпадает из ревью.

## Что происходит

`collect-context.sh` режет каждый файл канона на `MAX_FILE_BYTES` (8000) через `head -c`. Обрезка идёт по **байтовой** границе, а кириллица/тайский/CJK/эмодзи в UTF-8 занимают 2-4 байта — рез попадает в середину символа, и `ctx.md` заканчивается неполной последовательностью.

Дальше `review-codex.sh` кладёт этот контекст в `PROMPT`, и `codex exec review` отказывается от всего вызова:

```
error: invalid UTF-8 was detected in one or more arguments
Usage: codex exec review [OPTIONS] [PROMPT]
[exited with code 2]
```

Отказ уводит диагностику в сторону — сообщение указывает на аргументы, то есть на промпт, а не на файл контекста. У меня это заняло несколько попыток: я решил, что виновата кириллица в `--target`, повторил с целью на латинице — тот же отказ; настоящую причину увидел только когда запустил `codex exec review` **вообще без контекста** и получил уже честное «you've hit your usage limit». То есть один отказ прятал другой.

**OpenCode на том же входе не падает** — модель просто съедает битый байт. Так что испорченный канон доезжает до части ревьюеров молча, и «контекст доехал целым» неверно ни для одного из них.

Воспроизводится стабильно: у двух независимых сессий на одном и том же русском `CLAUDE.md` — `invalid continuation byte` на **одном и том же смещении 8031**, байт в байт.

## Замер трёх вариантов

На живом русском `CLAUDE.md` (тот же файл, `MAX_FILE_BYTES=8000`):

| Способ | Байт на выходе | UTF-8 |
|---|---|---|
| `head -c 8000` (как сейчас) | 8000 | **бит**, `invalid continuation byte` на 7999 |
| `head -c 8000 \| iconv -f utf-8 -t utf-8 -c` | 7999 | валиден, потерян 1 байт |
| `head -c 8000 \| sed '$d'` | 6980 | валиден, потеряна вся последняя строка |

## Что в патче

Функция `truncate_utf8`: `iconv -c`, когда он есть (сохраняет всё, кроме неполного символа), иначе — отбрасывание последней строки (граница строки всегда является границей символа). Новых зависимостей не добавляется: `iconv` в POSIX, а фолбэк — чистый shell.

Проверено: `bash -n` проходит, прогон на живом каноне даёт валидный `ctx.md` (22 860 байт), в котором раньше был битый байт.

## Оговорка

`iconv -c` я мерил на macOS. На GNU `iconv` неполный хвост в конце буфера — это «incomplete character», а не «invalid», и с `-c` он тоже не попадает в вывод, но код возврата может быть ненулевым (в конвейере это ни на что не влияет, вывод уже получен). Если хочется совсем без зависимости от поведения iconv — можно оставить только ветку с `sed '$d'`, ценой потери последней строки; я выбрал iconv как менее разрушительный вариант, но переключить это одна строка.
